### PR TITLE
Add recipe: Kid-Friendly Campfire Mac and Cheese

### DIFF
--- a/_posts/2024-09-17-kid-friendly-campfire-mac-and-cheese.md
+++ b/_posts/2024-09-17-kid-friendly-campfire-mac-and-cheese.md
@@ -1,0 +1,69 @@
+---
+layout: post
+title: "Kid-Friendly Campfire Mac and Cheese"
+tags: ["dinner", "camping", "gluten-free", "alpha-gal-safe", "kid-friendly"]
+---
+
+# Kid-Friendly Campfire Mac and Cheese (Gluten-Free, Alpha-Gal Safe)
+
+A creamy, crowd-pleasing mac and cheese that's familiar for kids and flavorful enough for adults. This version uses a blend of gluten-free and alpha-gal-friendly cheeses and can be made ahead, then finished at camp. Optional to bake or cook in a Dutch oven over coals.
+
+## Ingredients
+
+### For the pasta and sauce:
+- 8 oz gluten-free pasta
+- 2 tbsp butter (or dairy-free alternative)
+- 2 tbsp gluten-free flour (for roux)
+- 2 cups milk (or dairy-free milk)
+- 1/2 tsp salt (adjust to taste)
+- 1/4 tsp black pepper
+- 1/4 tsp mustard powder (optional)
+- 1/4 tsp paprika (optional)
+
+### Cheese blend (2 1/2 cups total):
+- 2 cups sharp cheddar (classic base, familiar to kids)
+- 1 cup Monterey Jack (melty and mild)
+- 1/2 cup Gruyère or Fontina (adds depth and creaminess)
+- 1/4 cup Parmesan (optional, salty umami boost)
+
+## Instructions
+
+1. **Cook pasta**: 
+   - Cook gluten-free pasta according to package instructions. Drain and set aside.
+
+2. **Make roux**:
+   - In a medium saucepan, melt butter over medium heat.
+   - Add gluten-free flour and whisk for 1–2 minutes until bubbly and lightly golden.
+
+3. **Add milk and thicken**:
+   - Slowly whisk in milk. Cook, stirring constantly, until the sauce thickens (5–7 minutes).
+
+4. **Season**:
+   - Stir in salt, pepper, mustard powder, and paprika.
+
+5. **Melt cheeses**:
+   - Gradually add the cheese blend (reserve a bit for topping if baking).
+   - Stir until smooth and fully melted.
+
+6. **Combine**:
+   - Mix the cheese sauce with cooked pasta. Stir until well coated.
+
+7. **Optional – Bake or campfire finish**:
+   - Pour into a Dutch oven or baking dish.
+   - Top with reserved cheese or gluten-free breadcrumbs.
+   - **Campfire**: Cover and bake over coals for 15–20 minutes, rotating occasionally.
+   - **Oven**: Bake at 375°F for 15–20 minutes until golden and bubbly.
+
+## Notes
+
+- **Make-ahead tip**: Pre-cook pasta, make the roux and sauce, and grate all cheeses ahead of time. Store in separate containers or combine into a single Dutch oven for easy campfire reheating.
+- **Gluten-Free**: Uses gluten-free flour, pasta, and breadcrumbs (if baked).
+- **Alpha-Gal Safe**: All ingredients are plant-based or poultry-derived; avoid any cheeses or butters made from mammal milk if necessary.
+- **Kid-friendly**: Cheddar and Monterey Jack offer familiar flavors. Gruyère or Fontina adds complexity without being overpowering. Parmesan is optional but gives a sharp edge adults will love.
+- **From our convo**: You were planning a camp meal with your kids and wanted something easy, comforting, and fun. This mac pairs great with cornbread (also made in the Dutch oven), and you mentioned adding black olives and peas as toppings for extra variety.
+
+## Optional Toppings
+- Sliced black olives
+- Blanched peas
+- Gluten-free breadcrumbs
+- Chopped chives or parsley


### PR DESCRIPTION
Fixes #23

Add recipe for Kid-Friendly Campfire Mac and Cheese (Gluten-Free, Alpha-Gal Safe).

* Create a new file `_posts/2024-09-17-kid-friendly-campfire-mac-and-cheese.md`.
* Set the layout to `post` and title to "Kid-Friendly Campfire Mac and Cheese".
* Add tags: ["dinner", "camping", "gluten-free", "alpha-gal-safe", "kid-friendly"].
* Include sections for Ingredients, Instructions, Notes, and Optional Toppings as provided in the issue description.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/gabeduke/recipes/pull/25?shareId=6720aa4a-e821-4f6a-9a45-d0fb3fa4244f).